### PR TITLE
Fixed booting error from indent_block_line in latest version of nvim

### DIFF
--- a/after/plugin/one_line_configs.lua
+++ b/after/plugin/one_line_configs.lua
@@ -7,11 +7,17 @@ require("neodev").setup()
 -- Enable Comment.nvim
 require("Comment").setup()
 
+
 -- Enable `lukas-reineke/indent-blankline.nvim`
 -- See `:help indent_blankline.txt`
-require("indent_blankline").setup({
-    char = "┊",
-    show_trailing_blankline_indent = false,
+require("ibl").setup({
+    indent = {
+        char = "┊",
+    },
+    scope = {
+        show_start = true,
+        show_end = false,
+    },
 })
 
 vim.keymap.set('n', '<leader>ut', vim.cmd.UndotreeToggle)


### PR DESCRIPTION
This pull request fixes error while booting nvim after upgrading nvim to latest version